### PR TITLE
fix bug for forwardRef

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,4 +37,6 @@ class Animation extends PureComponent {
   }
 }
 
-export default Animation;
+export default React.forwardRef((props, ref) => (
+  <Animation {...props} ref={typeof(ref)=='function'?c=>ref(c&&c.anim):ref} />
+))

--- a/src/index.js
+++ b/src/index.js
@@ -38,5 +38,5 @@ class Animation extends PureComponent {
 }
 
 export default React.forwardRef((props, ref) => (
-  <Animation {...props} ref={typeof(ref)=='function'?c=>ref(c&&c.anim):ref} />
-))
+  <Animation {...props} ref={typeof ref == 'function' ? c => ref(c && c.anim) : ref} />
+));


### PR DESCRIPTION
1、autoplay props is not effect
2、outside animtion obtained by ref point to this, will cause error occurred by animtion.play()
3、update the version of react to 16.3+ to support forwardRef