### PR TITLE
fix: pass className through

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ class Animation extends PureComponent {
   setAnimationDOMNode = ref => (this.animationDOMNode = ReactDOM.findDOMNode(ref));
 
   render() {
-    return <View style={this.props.style} ref={this.setAnimationDOMNode} />;
+    return <View style={this.props.style} className={this.props.className} ref={this.setAnimationDOMNode} />;
   }
 }
 


### PR DESCRIPTION
For example:

- `styled-component` in react-native-web will use className instead of style prop