### PR TITLE
docs: fix readme docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ resolve: {
 ```
 
 ## Usage
-See [Lottie's docs](http://airbnb.io/lottie/react-native/react-native.html/).
+See [Lottie's docs](https://airbnb.io/lottie/#/react-native).
 
 ## Examples
 See the [storybook](https://react-native-web-community.github.io/react-native-web-lottie/storybook).


### PR DESCRIPTION
The url on readme seems to take me to a dead link.

Fixed the url so that it would take people to react-native page on lottie docs

