### PR TITLE
Support for lottie-web rendererSettings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ class Animation extends PureComponent {
       renderer: 'svg',
       loop: props.loop || false,
       autoplay: props.autoPlay,
+      rendererSettings: props.rendererSettings || {},
     });
   };
 


### PR DESCRIPTION
Adding support for rendererSettings provided by the lottie web API.
Useful to override the canvas aspect ratio behavior.

