### PR TITLE
Make API much closer to `lottie-react-native` and add types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ resolve: {
 ```
 
 If you are using [Expo](https://docs.expo.dev/guides/customizing-webpack/), you can simply do
+
 ```js
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
 
-module.exports = async function(env, argv) {
+module.exports = async function (env, argv) {
   const config = await createExpoWebpackConfigAsync(env, argv);
 
   config.resolve.alias['lottie-react-native'] = 'react-native-web-lottie';

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.4",
   "description": "React Native for Web implementation of Lottie",
   "main": "dist/index.js",
+  "types": "src/index.d.ts",
   "main-es": "src/index.js",
   "repository": {
     "type": "git",
@@ -14,29 +15,17 @@
     "url": "https://github.com/Minishlink"
   },
   "license": "MIT",
-  "keywords": [
-    "react-native",
-    "react-native-web",
-    "lottie-react-native"
-  ],
+  "keywords": ["react-native", "react-native-web", "lottie-react-native"],
   "scripts": {
     "prepublish": "yarn build",
     "build": "mkdir -p dist && babel src --out-dir dist --copy-files",
     "test": "prettier --check ."
   },
   "babel": {
-    "presets": [
-      "module:metro-react-native-babel-preset"
-    ],
-    "plugins": [
-      "react-native-web"
-    ]
+    "presets": ["module:metro-react-native-babel-preset"],
+    "plugins": ["react-native-web"]
   },
-  "files": [
-    "src",
-    "dist",
-    "yarn.lock"
-  ],
+  "files": ["src", "dist", "yarn.lock"],
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,100 @@
+declare module "react-native-web-lottie" {
+  import { Animated, StyleProp, ViewStyle } from "react-native";
+  /**
+   * Serialized animation as generated from After Effects
+   */
+  export interface AnimationObject {
+    v: string;
+    fr: number;
+    ip: number;
+    op: number;
+    w: number;
+    h: number;
+    nm?: string;
+    ddd?: number;
+    assets: any[];
+    layers: any[];
+    markers?: any[];
+  }
+
+  export interface BaseRendererConfig {
+    imagePreserveAspectRatio?: string;
+    className?: string;
+  }
+
+  export interface FilterSizeConfig  {
+    width: string;
+    height: string;
+    x: string;
+    y: string;
+};
+
+  export interface SVGRendererConfig extends BaseRendererConfig {
+    title?: string;
+    description?: string;
+    preserveAspectRatio?: string;
+    progressiveLoad?: boolean;
+    hideOnTransparent?: boolean;
+    viewBoxOnly?: boolean;
+    viewBoxSize?: string;
+    focusable?: boolean;
+    filterSize?: FilterSizeConfig;
+  }
+
+  export interface AnimatedLottieViewProps {
+    /**
+     * The source of animation. Can be referenced as a local asset by a string, or remotely
+     * with an object with a `uri` property, or it can be an actual JS object of an
+     * animation, obtained (for example) with something like
+     * `require('../path/to/animation.json')`
+     */
+    source: string | AnimationObject | { uri: string };
+
+    progress: Animated.Value;
+
+    /**
+     * A boolean flag indicating whether or not the animation should loop.
+     */
+    loop?: boolean;
+
+    /**
+     * Style attributes for the view, as expected in a standard `View`:
+     * http://facebook.github.io/react-native/releases/0.39/docs/view.html#style
+     * CAVEAT: border styling is not supported.
+     */
+    style?: StyleProp<ViewStyle>;
+
+    /**
+     * A boolean flag indicating whether or not the animation should start automatically when
+     * mounted. This only affects the imperative API.
+     */
+    autoPlay?: boolean;
+
+
+    /**
+     * Check out lottie docs : https://airbnb.io/lottie/#/web?id=other-loading-options
+     */
+    rendererSettings ?: SVGRendererConfig;
+
+    /**
+     * A callback function which will be called when animation is finished. Note that this
+     * callback will be called only when `loop` is set to false.
+     */
+    onAnimationFinish?: (isCancelled: boolean) => void;
+
+    /**
+     * A string to identify the component during testing
+     */
+    testID?: string;
+  }
+
+  class AnimatedLottieView extends React.Component<
+    AnimatedLottieViewProps,
+    {}
+  > {
+    play(startFrame?: number, endFrame?: number): void;
+    reset(): void;
+  }
+
+  export default AnimatedLottieView;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,12 +22,12 @@ declare module "react-native-web-lottie" {
     className?: string;
   }
 
-  export interface FilterSizeConfig  {
+  export interface FilterSizeConfig {
     width: string;
     height: string;
     x: string;
     y: string;
-};
+  }
 
   export interface SVGRendererConfig extends BaseRendererConfig {
     title?: string;
@@ -50,7 +50,7 @@ declare module "react-native-web-lottie" {
      */
     source: string | AnimationObject | { uri: string };
 
-    progress: Animated.Value;
+    progress?: Animated.Value;
 
     /**
      * A boolean flag indicating whether or not the animation should loop.
@@ -70,11 +70,16 @@ declare module "react-native-web-lottie" {
      */
     autoPlay?: boolean;
 
+    /**
+     * The speed the animation will progress. This only affects the imperative API. The
+     * default value is 1.
+     */
+    speed?: number;
 
     /**
      * Check out lottie docs : https://airbnb.io/lottie/#/web?id=other-loading-options
      */
-    rendererSettings ?: SVGRendererConfig;
+    rendererSettings?: SVGRendererConfig;
 
     /**
      * A callback function which will be called when animation is finished. Note that this

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
-declare module "react-native-web-lottie" {
-  import { Animated, StyleProp, ViewStyle } from "react-native";
+declare module 'react-native-web-lottie' {
+  import { Animated, StyleProp, ViewStyle } from 'react-native';
   /**
    * Serialized animation as generated from After Effects
    */
@@ -93,10 +93,7 @@ declare module "react-native-web-lottie" {
     testID?: string;
   }
 
-  class AnimatedLottieView extends React.Component<
-    AnimatedLottieViewProps,
-    {}
-  > {
+  class AnimatedLottieView extends React.Component<AnimatedLottieViewProps, {}> {
     play(startFrame?: number, endFrame?: number): void;
     reset(): void;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,11 @@ class Animation extends PureComponent {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.source && nextProps.source && this.props.source.nm !== nextProps.source.nm) {
+    if (this.props.source && nextProps.source && (this.props.source.nm !== nextProps.source.nm || this.props.source.uri !== nextProps.source.uri)) {
       this.loadAnimation(nextProps);
+    }
+    if(this.props.speed !== nextProps.speed){
+      this.anim.setSpeed(nextProps.speed);
     }
   }
 
@@ -43,6 +46,10 @@ class Animation extends PureComponent {
       rendererSettings: props.rendererSettings || {},
       ...(props.source.uri && typeof props.source.uri === "string" ? {path:props.source.uri} : {animationData: props.source})
     });
+
+    if(props.speed !== undefined){
+      this.anim.setSpeed(props.speed)
+    }
 
     if (props.onAnimationFinish) {
       this.anim.addEventListener('complete', props.onAnimationFinish);

--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,14 @@ class Animation extends PureComponent {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.source && nextProps.source && (this.props.source.nm !== nextProps.source.nm || this.props.source.uri !== nextProps.source.uri)) {
+    if (
+      this.props.source &&
+      nextProps.source &&
+      (this.props.source.nm !== nextProps.source.nm || this.props.source.uri !== nextProps.source.uri)
+    ) {
       this.loadAnimation(nextProps);
     }
-    if(this.props.speed !== nextProps.speed){
+    if (this.props.speed !== nextProps.speed) {
       this.anim.setSpeed(nextProps.speed);
     }
   }
@@ -44,11 +48,13 @@ class Animation extends PureComponent {
       loop: props.loop || false,
       autoplay: props.autoPlay,
       rendererSettings: props.rendererSettings || {},
-      ...(props.source.uri && typeof props.source.uri === "string" ? {path:props.source.uri} : {animationData: props.source})
+      ...(props.source.uri && typeof props.source.uri === 'string'
+        ? { path: props.source.uri }
+        : { animationData: props.source }),
     });
 
-    if(props.speed !== undefined){
-      this.anim.setSpeed(props.speed)
+    if (props.speed !== undefined) {
+      this.anim.setSpeed(props.speed);
     }
 
     if (props.onAnimationFinish) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,11 +37,11 @@ class Animation extends PureComponent {
 
     this.anim = lottie.loadAnimation({
       container: this.animationDOMNode,
-      animationData: props.source,
       renderer: 'svg',
       loop: props.loop || false,
       autoplay: props.autoPlay,
       rendererSettings: props.rendererSettings || {},
+      ...(props.source.uri && typeof props.source.uri === "string" ? {path:props.source.uri} : {animationData: props.source})
     });
 
     if (props.onAnimationFinish) {


### PR DESCRIPTION
This PR tries to make the API much more closer to `lottie-react-native` package as it is supposed to be used alongside that. Following things are added 
- support for loading lottie files from a remote url. The `source` prop accepts `{uri: <remote url string>}`. This support was previously missing. We first check if the remote url is provided, if not fallback to using object as animation data.
- Add support for animation speed. This fixes #27 

 - Adds types for the projects. The types are copied from [types](https://github.com/lottie-react-native/lottie-react-native/blob/master/src/index.d.ts) of `lottie-react-native`
