### PR TITLE
Upgrade lottie-web dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "react-native-web": "*"
   },
   "dependencies": {
-    "lottie-web": "^5.7.1"
+    "lottie-web": "^5.10.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,10 +2343,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
-lottie-web@^5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.1.tgz#505f748a2dda836f7b582f811004c5ab8791c90c"
-  integrity sha512-f7kO4Qcurldc9SWfGUuwgs96/SCT+hwATMCdMK6I/sd6EYK3Y0Ciz40yAvq0x9uXzrk6KKcnQrqijZM8Ir4Drg==
+lottie-web@^5.10.2:
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.10.2.tgz#a1c952b6734759fcd369eba73b6b7e3d9a76ce0b"
+  integrity sha512-d0PFIGiwuMsJYaF4uPo+qG8dEorlI+xFI2zrrFtE1bGO4WoLIz+NjremxEq1swpR7juR10aeOtmNh3d6G3ub0A==
 
 lru-cache@^4.0.1:
   version "4.1.1"


### PR DESCRIPTION
This simple PR just upgrades the lottie-web dependency to take advantage of newer features and bug fixes.

Tested using the storybook, seems to work fine.